### PR TITLE
fix: #17 VxeNumberInput 无法手动输入小数点

### DIFF
--- a/examples/views/number-input/NumberInputTest.vue
+++ b/examples/views/number-input/NumberInputTest.vue
@@ -7,6 +7,8 @@
       <vxe-number-input v-model="demo1.value103" placeholder="超小尺寸" size="mini"></vxe-number-input>
     </p>
 
+小数间隔: {{ demo1.value503 }}
+
     <p>
       <vxe-number-input v-model="demo1.value500" placeholder="数值类型" type="number"></vxe-number-input>
       <vxe-number-input v-model="demo1.value501" placeholder="数值间隔 1.4" type="number" step="1.4" clearable></vxe-number-input>

--- a/packages/number-input/src/number-input.ts
+++ b/packages/number-input/src/number-input.ts
@@ -246,8 +246,11 @@ export default defineComponent({
       inputMethods.dispatchEvent(evnt.type, { value: inputValue }, evnt)
     }
 
-    const emitModel = (value: number | null, evnt: Event | { type: string }) => {
+    const emitModel = (value: number | null, evnt: Event | { type: string }, writeToInput = true) => {
       emit('update:modelValue', value ? Number(value) : null)
+      if (writeToInput) {
+        reactData.inputValue = value
+      }
       inputMethods.dispatchEvent('input', { value }, evnt as any)
       if (XEUtils.toValueString(props.modelValue) !== XEUtils.toValueString(value)) {
         inputMethods.dispatchEvent('change', { value }, evnt as any)
@@ -263,7 +266,7 @@ export default defineComponent({
       const value = inputValue ? Number(inputValue) : null
       reactData.inputValue = inputValue
       if (inpImmediate) {
-        emitModel(value, evnt)
+        emitModel(value, evnt, false)
       } else {
         inputMethods.dispatchEvent('input', { value }, evnt)
       }
@@ -298,7 +301,6 @@ export default defineComponent({
     const clearValueEvent = (evnt: Event, value: VxeNumberInputPropTypes.ModelValue) => {
       focus()
       emitModel(null, evnt)
-      reactData.inputValue = null
       inputMethods.dispatchEvent('clear', { value }, evnt)
     }
 
@@ -322,7 +324,6 @@ export default defineComponent({
           const validValue = inputValue ? Number(toFloatValueFixed(inputValue, digitsValue)) : null
           if (inputValue !== validValue) {
             emitModel(validValue, { type: 'init' })
-            reactData.inputValue = validValue
           }
         }
       }
@@ -356,7 +357,6 @@ export default defineComponent({
           }
           const numValue = getNumberValue(inpNumVal)
           emitModel(numValue, { type: 'check' })
-          reactData.inputValue = numValue
         }
       }
     }
@@ -367,7 +367,6 @@ export default defineComponent({
       const value = inputValue ? Number(inputValue) : null
       if (!inpImmediate) {
         emitModel(value, evnt)
-        reactData.inputValue = value
       }
       afterCheckValue()
       if (!reactData.visiblePanel) {

--- a/packages/number-input/src/number-input.ts
+++ b/packages/number-input/src/number-input.ts
@@ -247,7 +247,6 @@ export default defineComponent({
     }
 
     const emitModel = (value: number | null, evnt: Event | { type: string }) => {
-      reactData.inputValue = value
       emit('update:modelValue', value ? Number(value) : null)
       inputMethods.dispatchEvent('input', { value }, evnt as any)
       if (XEUtils.toValueString(props.modelValue) !== XEUtils.toValueString(value)) {
@@ -299,6 +298,7 @@ export default defineComponent({
     const clearValueEvent = (evnt: Event, value: VxeNumberInputPropTypes.ModelValue) => {
       focus()
       emitModel(null, evnt)
+      reactData.inputValue = null
       inputMethods.dispatchEvent('clear', { value }, evnt)
     }
 
@@ -322,6 +322,7 @@ export default defineComponent({
           const validValue = inputValue ? Number(toFloatValueFixed(inputValue, digitsValue)) : null
           if (inputValue !== validValue) {
             emitModel(validValue, { type: 'init' })
+            reactData.inputValue = validValue
           }
         }
       }
@@ -353,7 +354,9 @@ export default defineComponent({
               inpNumVal = Number(inpStringVal)
             }
           }
-          emitModel(getNumberValue(inpNumVal), { type: 'check' })
+          const numValue = getNumberValue(inpNumVal)
+          emitModel(numValue, { type: 'check' })
+          reactData.inputValue = numValue
         }
       }
     }
@@ -364,6 +367,7 @@ export default defineComponent({
       const value = inputValue ? Number(inputValue) : null
       if (!inpImmediate) {
         emitModel(value, evnt)
+        reactData.inputValue = value
       }
       afterCheckValue()
       if (!reactData.visiblePanel) {


### PR DESCRIPTION
在 `input` 事件调用 `emitInputEvent` 函数设置当前输入的值，在这个函数中将当前输入的字符记录到了 `reactData.inputValue` 中。但由于 `props.immediate` 默认为 `true` 所以额外调用了一次 `emitModel(value, event)` ，在 `emitModel` 函数中又设置了一次 `reactData.inputValue` 导致 BUG 触发。因为传递给 `emitModel` value 值是一个已经被 `Number` 处理过的数值。
如果输入了 `3.` 那么 `Number` 处理过后就变成了 `3` 而不是 `3.` 或者 `3.0`。

## 这个 PR 做了什么？

由于 `VxeNumberInput` 组件对外输出的数据是一个 `number` 而组件内部需要 string 来记录当前输入状态。所以 `reactData.inputValue` 就应该是 `input` 组件的输入值而不是最终输出结果。因此不应该在 `emitModel` 中直接设置它。

该 PR 为 `emitModel` 添加了 `writeToInput = true` 参数控制当前 emit 是否需要更新 input value。在 `emitInputEvent` 函数中并不需要更新它。