### PR TITLE
feat: 1. 针对vxe-form表单新增动态layout配置，可自定义开启表单动态栅格系统，开启后根据屏幕尺寸自动排列2.扩展新增微前端模式边界值计算Feature makai

### DIFF
--- a/examples/views/form/FormTest.vue
+++ b/examples/views/form/FormTest.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <!-- <vxe-form vertical title-colon :data="demo1.formData1" @submit="searchEvent" @reset="resetEvent">
+    <vxe-form vertical title-colon :data="demo1.formData1" @submit="searchEvent" @reset="resetEvent">
       <vxe-form-item title="名称" field="name" :item-render="{}" titleBold>
         <template #default="{ data }">
           <vxe-input v-model="data.name" placeholder="请输入名称" clearable></vxe-input>
@@ -246,15 +246,11 @@
           </vxe-form-item>
         </div>
       </div>
-    </vxe-form> -->
+    </vxe-form>
 
     <p class="tip">配置式表单</p>
 
-<<<<<<< HEAD
-    <vxe-form :data="demo4.formData4" :items="demo4.formItems4">
-=======
     <vxe-form :data="demo4.formData4" :items="demo4.formItems4" :useDynamicSpan="true" :dynamicSpan="demo4.dynamicSpan">
->>>>>>> master
       <template #myaddress="{ data }">
         <vxe-input v-model="data.address" placeholder="自定义插槽模板"></vxe-input>
       </template>
@@ -379,34 +375,6 @@ const demo4 = reactive({
     val3: '',
     flag: false,
     address: ''
-<<<<<<< HEAD
-  },
-  formItems4: [
-    {
-      title: '左侧',
-      span: 12,
-      children: [
-        { field: 'name', title: '名称', span: 8, itemRender: { name: '$input', props: { placeholder: '请输入名称' } } },
-        { field: 'sex', title: '性别', span: 8, itemRender: { name: '$select', options: [{ value: '0', label: '女' }, { value: '1', label: '男' }], props: { placeholder: '请选择性别' } } },
-        { field: 'role', title: '角色', span: 8, itemRender: { name: '$input', props: { placeholder: '请输入角色' } } },
-        { field: 'age', title: '年龄', span: 24, itemRender: { name: '$input', props: { type: 'number', placeholder: '请输入年龄' } } },
-        { field: 'region', title: '地区选择', span: 24, itemRender: { name: 'VxeTreeSelect', options: regionOptions.value } },
-        { field: 'val1', title: '复选框-组', span: 12, itemRender: { name: '$checkbox', options: [{ label: '爬山', value: '11' }, { label: '健身', value: '22' }] } },
-        { field: 'val2', title: '复选框', span: 12, itemRender: { name: '$checkbox' } },
-        { field: 'val3', title: '单选框', span: 12, itemRender: { name: '$radio', options: [{ label: '是', value: 'Y' }, { label: '否', value: 'N' }] } },
-        { field: 'flag', title: '开关', span: 24, itemRender: { name: '$switch', props: { openLabel: '是', closeLabel: '否' } } },
-        { field: 'address', title: '地区', span: 24, slots: { default: 'myaddress' } }
-      ]
-    },
-    {
-      title: '右侧',
-      span: 12,
-      children: [
-        { field: 'nickname', title: '昵称', span: 24, itemRender: { name: '$input', props: { placeholder: '请输入昵称' } } }
-      ]
-    },
-    { align: 'center', span: 24, itemRender: { name: '$buttons', children: [{ props: { type: 'submit', content: '配置式表单', status: 'primary' } }, { props: { type: 'reset', content: '重置' } }] } }
-=======
   },
   dynamicSpan: {
     colProps: {
@@ -433,7 +401,6 @@ const demo4 = reactive({
     { field: 'flag', title: '开关', folding: true, span: 8, itemRender: { name: '$switch', props: { openLabel: '是', closeLabel: '否' } } },
     { field: 'nickname', title: '昵称', folding: true, span: 8, itemRender: { name: '$input', props: { placeholder: '请输入昵称' } } },
     { align: 'center', span: 8, collapseNode: true, itemRender: { name: '$buttons', children: [{ props: { type: 'submit', content: '配置式表单', status: 'primary' } }, { props: { type: 'reset', content: '重置' } }] } }
->>>>>>> master
   ]
 })
 

--- a/examples/views/form/FormTest.vue
+++ b/examples/views/form/FormTest.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <vxe-form vertical title-colon :data="demo1.formData1" @submit="searchEvent" @reset="resetEvent">
+    <!-- <vxe-form vertical title-colon :data="demo1.formData1" @submit="searchEvent" @reset="resetEvent">
       <vxe-form-item title="名称" field="name" :item-render="{}" titleBold>
         <template #default="{ data }">
           <vxe-input v-model="data.name" placeholder="请输入名称" clearable></vxe-input>
@@ -246,11 +246,15 @@
           </vxe-form-item>
         </div>
       </div>
-    </vxe-form>
+    </vxe-form> -->
 
     <p class="tip">配置式表单</p>
 
+<<<<<<< HEAD
     <vxe-form :data="demo4.formData4" :items="demo4.formItems4">
+=======
+    <vxe-form :data="demo4.formData4" :items="demo4.formItems4" :useDynamicSpan="true" :dynamicSpan="demo4.dynamicSpan">
+>>>>>>> master
       <template #myaddress="{ data }">
         <vxe-input v-model="data.address" placeholder="自定义插槽模板"></vxe-input>
       </template>
@@ -375,6 +379,7 @@ const demo4 = reactive({
     val3: '',
     flag: false,
     address: ''
+<<<<<<< HEAD
   },
   formItems4: [
     {
@@ -401,6 +406,34 @@ const demo4 = reactive({
       ]
     },
     { align: 'center', span: 24, itemRender: { name: '$buttons', children: [{ props: { type: 'submit', content: '配置式表单', status: 'primary' } }, { props: { type: 'reset', content: '重置' } }] } }
+=======
+  },
+  dynamicSpan: {
+    colProps: {
+      md: 8,
+      lg: 6,
+      xl: 6
+    },
+    actionColProps: {
+      span: 24
+    },
+    autoAction: true,
+    alwaysShowLines: 2
+  },
+  formItems4: [
+    { field: 'name', title: '名称', span: 8, itemRender: { name: '$input', props: { placeholder: '请输入名称' } } },
+    { field: 'sex', title: '性别', span: 8, itemRender: { name: '$select', options: [{ value: '0', label: '女' }, { value: '1', label: '男' }], props: { placeholder: '请选择性别' } } },
+    { field: 'role', title: '角色', span: 8, itemRender: { name: '$input', props: { placeholder: '请输入角色' } } },
+    { field: 'address', title: '地区', folding: true, span: 8, slots: { default: 'myaddress' }, visibleMethod: ({data}) => data.name === '1111' },
+    { field: 'age', title: '年龄', folding: true, span: 8, itemRender: { name: '$input', props: { type: 'number', placeholder: '请输入年龄' } } },
+    { field: 'region', title: '地区选择', folding: true, span: 8, itemRender: { name: 'VxeTreeSelect', options: regionOptions.value } },
+    { field: 'val1', title: '复选框-组', folding: true, span: 8, itemRender: { name: '$checkbox', options: [{ label: '爬山', value: '11' }, { label: '健身', value: '22' }] } },
+    { field: 'val2', title: '复选框', folding: true, span: 8, itemRender: { name: '$checkbox' } },
+    { field: 'val3', title: '单选框', folding: true, span: 8, itemRender: { name: '$radio', options: [{ label: '是', value: 'Y' }, { label: '否', value: 'N' }] } },
+    { field: 'flag', title: '开关', folding: true, span: 8, itemRender: { name: '$switch', props: { openLabel: '是', closeLabel: '否' } } },
+    { field: 'nickname', title: '昵称', folding: true, span: 8, itemRender: { name: '$input', props: { placeholder: '请输入昵称' } } },
+    { align: 'center', span: 8, collapseNode: true, itemRender: { name: '$buttons', children: [{ props: { type: 'submit', content: '配置式表单', status: 'primary' } }, { props: { type: 'reset', content: '重置' } }] } }
+>>>>>>> master
   ]
 })
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "style": "lib/style.css",
   "typings": "types/index.d.ts",
   "dependencies": {
-    "@vxe-ui/core": "^1.0.12"
+    "@vxe-ui/core": "^1.0.12",
+    "dom-zindex": "^1.0.4",
+    "xe-utils": "^3.5.28"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -38,6 +40,7 @@
     "@vue/cli-service": "~5.0.0",
     "@vue/eslint-config-standard": "^6.1.0",
     "@vue/eslint-config-typescript": "^9.1.0",
+    "@vueuse/core": "^10.11.0",
     "core-js": "^3.8.3",
     "del": "^6.1.1",
     "eslint": "^7.32.0",

--- a/packages/form/src/form-calc-span.ts
+++ b/packages/form/src/form-calc-span.ts
@@ -1,0 +1,152 @@
+import type { ComputedRef, Ref } from 'vue'
+import type { VxeFormProps, VxeFormItemProps, VxeFormConstructor, VxeFormPrivateMethods, VxeFormPropTypes } from '../../../types'
+import { useWindowSize, useDebounceFn } from '@vueuse/core'
+import { watch, unref, computed } from 'vue'
+import XEUtils from 'xe-utils'
+
+interface UseFormCalcContext {
+  isCollapse: ComputedRef<boolean>;
+  getProps: ComputedRef<VxeFormProps>;
+  schemas: Ref<VxeFormItemProps[]>
+  $xeForm: VxeFormConstructor & VxeFormPrivateMethods
+  updateSchemas: (items: VxeFormItemProps[]) => void
+}
+
+const BASIC_COL_LEN = 24
+const DEFAULTSPAN: VxeFormPropTypes.DynamicSpanConfig = {
+  colProps: {
+    span: BASIC_COL_LEN,
+    xs: 0,
+    sm: 0,
+    md: 0,
+    lg: 0,
+    xl: 0
+  },
+  actionColProps: {
+    span: BASIC_COL_LEN,
+    xs: 0,
+    sm: 0,
+    md: 0,
+    lg: 0,
+    xl: 0
+  }
+}
+
+export default function ({ isCollapse, getProps, schemas, $xeForm, updateSchemas }: UseFormCalcContext) {
+  const { useDynamicSpan, dynamicSpan, isMicroApp } = getProps.value
+
+  if (!useDynamicSpan) return false
+  const formItems = unref(schemas.value)
+  const { width } = useWindowSize()
+  const showAdvancedButton = computed(() => {
+    const actionItem = formItems.find(schema => schema.hasOwnProperty('collapseNode'))
+    if (actionItem) {
+      const { visible, visibleMethod, field } = actionItem
+      let isShow = true
+      if (visible) {
+        isShow = true
+      }
+
+      if (visibleMethod && typeof visibleMethod === 'function') {
+        const { data } = $xeForm.props
+        isShow = visibleMethod({ data, field: `${field}`, property: `${field}`, item: actionItem as any, $form: $xeForm, $grid: $xeForm.xegrid })
+      }
+      return isShow
+    }
+    return false
+  })
+  const { alwaysShowLines, colProps, actionColProps, autoAction } = XEUtils.merge(DEFAULTSPAN, dynamicSpan || {})
+  let rowSpan = BASIC_COL_LEN
+  let lastSpan = BASIC_COL_LEN
+
+  function updateAdvanced () {
+    let itemColSum = 0
+    const windowW = isMicroApp ? window.parent.innerWidth : width.value
+    const xsWidth = parseInt(colProps.xs as string) || (colProps.span as number) || BASIC_COL_LEN
+    const smWidth = parseInt(colProps.sm as string) || xsWidth
+    const mdWidth = parseInt(colProps.md as string) || smWidth
+    const lgWidth = parseInt(colProps.lg as string) || mdWidth
+    const xlWidth = parseInt(colProps.xl as string) || lgWidth
+
+    const xsAcWidth = parseInt(actionColProps.xs as string) || (actionColProps.span as number) || BASIC_COL_LEN
+    const smAcWidth = parseInt(actionColProps.sm as string) || xsAcWidth
+    const mdAcWidth = parseInt(actionColProps.md as string) || smAcWidth
+    const lgAcWidth = parseInt(actionColProps.lg as string) || mdAcWidth
+    const xlAcWidth = parseInt(actionColProps.xl as string) || lgAcWidth
+
+    if (windowW < 768) {
+      rowSpan = xsWidth
+      if (!autoAction) {
+        lastSpan = xsAcWidth
+      }
+    } else if (windowW >= 768 && windowW < 992) {
+      rowSpan = smWidth
+      if (!autoAction) {
+        lastSpan = smAcWidth
+      }
+    } else if (windowW >= 992 && windowW < 1200) {
+      rowSpan = mdWidth
+      if (!autoAction) {
+        lastSpan = mdAcWidth
+      }
+    } else if (windowW >= 1200 && windowW < 1920) {
+      rowSpan = lgWidth
+      if (!autoAction) {
+        lastSpan = lgAcWidth
+      }
+    } else {
+      rowSpan = xlWidth
+      if (!autoAction) {
+        lastSpan = xlAcWidth
+      }
+    }
+
+    formItems.forEach(schema => {
+      const { visible, visibleMethod, field } = schema
+      let isShow = true
+      if (visible) {
+        isShow = true
+      }
+
+      if (visibleMethod && typeof visibleMethod === 'function') {
+        const { data } = $xeForm.props
+        isShow = visibleMethod({ data, field: `${field}`, property: `${field}`, item: schema as any, $form: $xeForm, $grid: $xeForm.xegrid })
+      }
+      if (schema.hasOwnProperty('collapseNode')) {
+        if (autoAction) {
+          lastSpan = isCollapse.value ? rowSpan : BASIC_COL_LEN - (itemColSum % BASIC_COL_LEN)
+        }
+        schema.span = lastSpan
+        itemColSum += isShow ? schema.span : 0
+        schema.collapseNode = itemColSum > (BASIC_COL_LEN * (alwaysShowLines || 1))
+      } else {
+        schema.span = rowSpan
+        itemColSum += isShow ? schema.span : 0
+        if (isCollapse.value) {
+          schema.folding = itemColSum > (BASIC_COL_LEN * (alwaysShowLines || 1) - (autoAction ? rowSpan : 0))
+        } else {
+          schema.folding = false
+        }
+      }
+    })
+    updateSchemas(formItems)
+  }
+
+  const debounceUpdateAdvanced = useDebounceFn(updateAdvanced, 50)
+
+  function handlerAdvanced () {
+    if (showAdvancedButton.value) {
+      debounceUpdateAdvanced()
+    }
+  }
+
+  watch(
+    [() => isCollapse.value, () => schemas.value, () => width.value],
+    () => {
+      handlerAdvanced()
+    },
+    { immediate: true }
+  )
+
+  return { handlerAdvanced }
+}

--- a/packages/form/src/itemInfo.ts
+++ b/packages/form/src/itemInfo.ts
@@ -33,7 +33,10 @@ export class ItemInfo {
       showError: false,
       errRule: null,
       slots: item.slots,
-      children: []
+      children: [],
+      isMicroApp: false,
+      useDynamicSpan: false,
+      dynamicSpan: null
     })
   }
 

--- a/packages/form/src/mitt.ts
+++ b/packages/form/src/mitt.ts
@@ -1,0 +1,32 @@
+class Mitt {
+  map: Map<string, any>
+  constructor () {
+    this.map = new Map()
+  }
+
+  emit (name: string, params?: any) {
+    const item = this.map.get(name)
+    if (item) item.slice().forEach((fn: (_params: any) => any) => fn(params))
+  }
+
+  on (name: string, fn: (params?: any) => any) {
+    const item = this.map.get(name)
+    if (item && item.length) item.push(fn)
+    else this.map.set(name, [fn])
+  }
+
+  off (name: string, fn: (params?: any) => any) {
+    const item: ((args?: any) => any)[] = this.map.get(name)
+    if (item) {
+      const index = item.slice().findIndex((f) => f === fn)
+      if (index > -1) item.splice(index, 1)
+      else this.map.set(name, [])
+    }
+  }
+
+  clear () {
+    this.map.clear()
+  }
+}
+
+export default new Mitt()

--- a/packages/form/src/util.ts
+++ b/packages/form/src/util.ts
@@ -3,7 +3,7 @@ import { renderer } from '../../ui'
 import XEUtils from 'xe-utils'
 import { ItemInfo } from './itemInfo'
 import { isEnableConf } from '../../ui/src/utils'
-
+import mitt from './mitt'
 import type { VxeFormConstructor, VxeFormDefines } from '../../../types'
 
 export interface XEFormItemProvide {
@@ -46,7 +46,9 @@ export function isActiveItem ($xeForm: VxeFormConstructor, formItem: VxeFormDefi
     return true
   }
   const { data } = $xeForm.props
-  return visibleMethod({ data, field, property: field, item: formItem, $form: $xeForm, $grid: $xeForm.xegrid })
+  const show = visibleMethod({ data, field, property: field, item: formItem, $form: $xeForm, $grid: $xeForm.xegrid })
+  mitt.emit('updateAdvanced', show)
+  return show
 }
 
 export function watchItem (props: any, formItem: ItemInfo) {

--- a/packages/ui/src/dom.ts
+++ b/packages/ui/src/dom.ts
@@ -95,9 +95,11 @@ export function getOffsetPos (elem: any, container: any) {
 }
 
 export function getAbsolutePos (elem: any) {
+  // 当页面作为子应用或者嵌套在iframe内时，计算tooltip边界值需要考虑body的边界距离，避免造成tooltip的位置偏离，其他组件不受影响
+  const bodyBounding = document.body.getBoundingClientRect()
   const bounding = elem.getBoundingClientRect()
-  const boundingTop = bounding.top
-  const boundingLeft = bounding.left
+  const boundingTop = bounding.top - bodyBounding.top
+  const boundingLeft = bounding.left - bodyBounding.left
   const { scrollTop, scrollLeft, visibleHeight, visibleWidth } = getDomNode()
   return { boundingTop, top: scrollTop + boundingTop, boundingLeft, left: scrollLeft + boundingLeft, visibleHeight, visibleWidth }
 }

--- a/types/components/form.d.ts
+++ b/types/components/form.d.ts
@@ -79,6 +79,27 @@ export namespace VxeFormPropTypes {
   export interface TooltipOpts extends TooltipConfig { }
 
   export type CustomLayout = boolean
+
+  export interface DynamicSpanConfig {
+    colProps: {
+      span?: TitleWidth
+      xs?: TitleWidth
+      sm?: TitleWidth
+      md?: TitleWidth
+      lg?: TitleWidth
+      xl?: TitleWidth
+    }
+    actionColProps: {
+      span?: TitleWidth
+      xs?: TitleWidth
+      sm?: TitleWidth
+      md?: TitleWidth
+      lg?: TitleWidth
+      xl?: TitleWidth
+    }
+    autoAction?: boolean
+    alwaysShowLines?: number
+  }
 }
 
 export type VxeFormProps<D = any> = {
@@ -104,6 +125,9 @@ export type VxeFormProps<D = any> = {
   validConfig?: VxeFormPropTypes.ValidConfig
   tooltipConfig?: VxeFormPropTypes.TooltipConfig
   customLayout?: VxeFormPropTypes.CustomLayout
+  isMicroApp?: VxeFormPropTypes.CollapseStatus
+  useDynamicSpan?: VxeFormPropTypes.CollapseStatus,
+  dynamicSpan?: VxeFormPropTypes.DynamicSpanConfig
 }
 
 export interface FormPrivateComputed {
@@ -236,6 +260,9 @@ export namespace VxeFormDefines {
     errRule: any
     slots: VxeFormItemPropTypes.Slots
     children: ItemInfo[]
+    isMicroApp?: VxeFormPropTypes.CollapseStatus
+    useDynamicSpan?: VxeFormPropTypes.CollapseStatus
+    dynamicSpan?: VxeFormPropTypes.DynamicSpanConfig
   }
 
   export interface FormRule<D = any> {

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,7 +10,8 @@ process.env.VUE_APP_VXE_VERSION = pkg.version
 process.env.VUE_APP_VXE_ENV = 'development'
 
 const externalMaps = {
-  'xe-utils': 'XEUtils'
+  'xe-utils': 'XEUtils',
+  '@vueuse/core': '@vueuse/core'
 }
 
 const externals = {}
@@ -37,6 +38,14 @@ module.exports = defineConfig({
       template: 'public/index.html',
       filename: 'index.html'
     }
+  },
+  devServer: {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': '*',
+      'Access-Control-Allow-Methods': '*'
+    },
+    port: '8080'
   },
   configureWebpack: {
     performance: {


### PR DESCRIPTION
暂未写md文档，但是新增formTest.vue使用示例, 新增了ts 静态类型，我已测试，动态栅格的逻辑是参考的vben的form表单，请帮忙复审后合并