### PR TITLE
fix(upload): 解决上传的文件后缀解析错误

### DIFF
--- a/packages/upload/src/upload.ts
+++ b/packages/upload/src/upload.ts
@@ -393,9 +393,10 @@ export default defineComponent({
     }
 
     const parseFileType = (name: string) => {
-      const index = name ? name.indexOf('.') : -1
-      if (index > -1) {
-        return name.substring(index + 1, name.length).toLowerCase()
+      // 这里不用split('.').pop()因为没有后缀时会返回自身
+      const index = name.lastIndexOf('.')
+      if (index > 0) {
+          return name.substring(index + 1).toLowerCase()
       }
       return ''
     }


### PR DESCRIPTION
问题描述：
当文件名中包含多个“点”时，后缀取的不对

解决：
应当从后往前找