### PR TITLE
fix: the type TooltipConfig has added a useHTML declaration

### DIFF
--- a/types/components/table.d.ts
+++ b/types/components/table.d.ts
@@ -1385,6 +1385,7 @@ export namespace VxeTablePropTypes {
     minHeight?: VxeTooltipPropTypes.MinHeight
     maxWidth?: VxeTooltipPropTypes.MaxWidth
     maxHeight?: VxeTooltipPropTypes.MaxHeight
+    useHTML?: VxeTooltipPropTypes.UseHTML
     contentMethod?(params: {
       $table: VxeTableConstructor<D>
       items: any[]


### PR DESCRIPTION
表格使用 tooltipConfig 的 useHTML 配置时 ts 检查报错
<img width="784" height="158" alt="lQLPKd43qTGeK0vMns0DELC6KCdBbR6h9wjGFbe1C1MA_784_158" src="https://github.com/user-attachments/assets/ee28f040-da9d-4eb3-8cda-adf31178a10f" />
