### PR TITLE
fix: 移除关闭模态框时的活动模态框引用

### DIFF
--- a/packages/modal/src/modal.ts
+++ b/packages/modal/src/modal.ts
@@ -1464,6 +1464,7 @@ export default defineVxeComponent({
       globalEvents.off($xeModal, 'keydown')
       removeMsgQueue()
       removeBodyLockScroll()
+      XEUtils.remove(allActiveModals, item => item === $xeModal)
     })
 
     provide('$xeModal', $xeModal)


### PR DESCRIPTION
用户通过路由跳转或 v-if 直接销毁了 Modal 组件（而不是通过点击关闭按钮），该组件的引用会一直残留在 allActiveModals 中